### PR TITLE
Fixed windows incompatability issues.

### DIFF
--- a/adal.gemspec
+++ b/adal.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.homepage = 'https://msopentech.com'
   s.email = 'msopentech@microsoft.com'
 
-  s.add_runtime_dependency 'escape_utils', '~> 1.1'
   s.add_runtime_dependency 'jwt', '~> 1.5'
   s.add_runtime_dependency 'nokogiri', '~> 1.6'
   s.add_runtime_dependency 'uri_template', '~> 0.7'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,7 @@ end
 require 'adal'
 
 # Don't print any logs from ADAL::Logger.
-ADAL::Logging.log_output = '/dev/null'
+ADAL::Logging.log_output = File.open(File::NULL, 'w')
 
 # Unit tests do not need network access. Any attempts to access the network
 # will throw exceptions.


### PR DESCRIPTION
`bundle install` and `bundle exec rake spec` both run correctly on cygwin 1.7.35.
