### PR TITLE
Made private_class_method syntax backwards compatible.

### DIFF
--- a/adal.gemspec
+++ b/adal.gemspec
@@ -33,6 +33,8 @@ Gem::Specification.new do |s|
   s.homepage = 'https://msopentech.com'
   s.email = 'msopentech@microsoft.com'
 
+  s.required_ruby_version = '>= 2.0.0'
+
   s.add_runtime_dependency 'jwt', '~> 1.5'
   s.add_runtime_dependency 'nokogiri', '~> 1.6'
   s.add_runtime_dependency 'uri_template', '~> 0.7'

--- a/lib/adal/authentication_parameters.rb
+++ b/lib/adal/authentication_parameters.rb
@@ -88,7 +88,7 @@ module ADAL
     #
     # @param String challenge
     # @return Hash
-    private_class_method def self.parse_challenge(challenge)
+    def self.parse_challenge(challenge)
       if challenge !~ BEARER_CHALLENGE_VALIDATION
         logger.warn("#{challenge} is not parseable as an RFC6750 OAuth2 " \
                     'challenge.')
@@ -96,6 +96,7 @@ module ADAL
       end
       Hash[challenge.scan(FIRST_KEY_VALUE) + challenge.scan(OTHER_KEY_VALUE)]
     end
+    private_class_method :parse_challenge
 
     ##
     # Constructs a new AuthenticationParameters.

--- a/lib/adal/mex_response.rb
+++ b/lib/adal/mex_response.rb
@@ -59,7 +59,7 @@ module ADAL
     # @param Nokogiri::XML::Document xml
     # @param Array[String] policy_ids
     # @return Array[String]
-    private_class_method def self.parse_bindings(xml, policy_ids)
+    def self.parse_bindings(xml, policy_ids)
       matching_bindings = xml.xpath(BINDING_XPATH, NAMESPACES).map do |node|
         reference_uri = node.xpath('./wsp:PolicyReference/@URI', NAMESPACES)
         node.xpath('./@name').to_s if policy_ids.include? reference_uri.to_s
@@ -67,11 +67,12 @@ module ADAL
       fail MexError, 'No matching bindings found.' if matching_bindings.empty?
       matching_bindings
     end
+    private_class_method :parse_bindings
 
     # @param Nokogiri::XML::Document xml
     # @param Array[String] bindings
     # @return Array[[String, String]]
-    private_class_method def self.parse_all_endpoints(xml, bindings)
+    def self.parse_all_endpoints(xml, bindings)
       endpoints = xml.xpath(PORT_XPATH, NAMESPACES).map do |node|
         binding = node.attr('binding').split(':').last
         if bindings.include? binding
@@ -80,11 +81,12 @@ module ADAL
       end.compact
       endpoints
     end
+    private_class_method :parse_all_endpoints
 
     # @param Nokogiri::XML::Document xml
     # @param Array[String] bindings
     # @return [String, String]
-    private_class_method def self.parse_endpoint_and_binding(xml, bindings)
+    def self.parse_endpoint_and_binding(xml, bindings)
       endpoints = parse_all_endpoints(xml, bindings)
       case endpoints.size
       when 0
@@ -96,22 +98,25 @@ module ADAL
       end
       prefer_13(endpoints).first
     end
+    private_class_method :parse_endpoint_and_binding
 
     # @param Nokogiri::XML::Document xml
     # @return Array[String]
-    private_class_method def self.parse_policy_ids(xml)
+    def self.parse_policy_ids(xml)
       policy_ids = xml.xpath(POLICY_ID_XPATH, NAMESPACES)
                    .map { |attr| "\##{attr.value}" }
       fail MexError, 'No username token policy nodes.' if policy_ids.empty?
       policy_ids
     end
+    private_class_method :parse_policy_ids
 
     # @param Array[String, String] endpoints
     # @return Array[String, String] endpoints
-    private_class_method def self.prefer_13(endpoints)
+    def self.prefer_13(endpoints)
       only13 = endpoints.select { |_, b| BINDING_TO_ACTION[b] == WSTRUST_13 }
       only13.empty? ? endpoints : only13
     end
+    private_class_method :prefer_13
 
     attr_reader :action
     attr_reader :wstrust_url

--- a/lib/adal/wstrust_response.rb
+++ b/lib/adal/wstrust_response.rb
@@ -96,13 +96,14 @@ module ADAL
 
     # @param Nokogiri::XML::Document xml
     # @return String
-    private_class_method def self.format_xml(xml)
+    def self.format_xml(xml)
       xml.to_s.split("\n").map(&:strip).join
     end
+    private_class_method :format_xml
 
     # @param Nokogiri::XML::Document
     # @return [Nokogiri::XML::Element, Nokogiri::XML::Text]
-    private_class_method def self.parse_token(xml, namespace)
+    def self.parse_token(xml, namespace)
       xml.xpath(TOKEN_RESPONSE_XPATH, namespace).select do |node|
         requested_token = node.xpath(SECURITY_TOKEN_XPATH, namespace)
         case requested_token.size
@@ -118,14 +119,16 @@ module ADAL
         end
       end
     end
+    private_class_method :parse_token
 
     # @param Nokogiri::XML::Element token_response_node
     # @return Nokogiri::XML::Text
-    private_class_method def self.parse_token_type(token_response_node)
+    def self.parse_token_type(token_response_node)
       type = token_response_node.xpath(TOKEN_TYPE_XPATH, NAMESPACES).first
       logger.warn('No type in token response node.') if type.nil?
       type
     end
+    private_class_method :parse_token_type
 
     attr_reader :token
 


### PR DESCRIPTION
Apparently the syntax

```
private_class_method def self.foo
  ...
end
```

is actually an undocumented feature that was added somwhere around 2.1.x.

The traditional OOP syntax is

```
def self.foo
  ...
end
private_class_method :foo
```

See: http://ruby-doc.org/core-2.0.0/Module.html#method-i-private_class_method
