### PR TITLE
Updated Ruby version requirement.

### DIFF
--- a/adal.gemspec
+++ b/adal.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://msopentech.com'
   s.email = 'msopentech@microsoft.com'
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.1.0'
 
   s.add_runtime_dependency 'jwt', '~> 1.5'
   s.add_runtime_dependency 'nokogiri', '~> 1.6'


### PR DESCRIPTION
ADAL Ruby uses Array#to_h, which was apparently not added until 2.1.0.

Note that to_h appears here: http://ruby-doc.org/core-2.1.0/Array.html

but not here: http://ruby-doc.org/core-2.0.0/Array.html

Some days I miss the stability of Java.
