### PR TITLE
Update client_assertion_certificate.rb

### DIFF
--- a/lib/adal/client_assertion_certificate.rb
+++ b/lib/adal/client_assertion_certificate.rb
@@ -21,6 +21,7 @@
 #-------------------------------------------------------------------------------
 
 require 'openssl'
+require_relative 'request_parameters.rb'
 
 module ADAL
   # An assertion made by a client with an X509 certificate. This requires both


### PR DESCRIPTION
Rake tasks are broken in Rails 4.0.1

I had to add this relative_require to get the Gem to load.
