### PR TITLE
adal:token_response: Check that raw_response is not an empty string b…

### DIFF
--- a/lib/adal/token_response.rb
+++ b/lib/adal/token_response.rb
@@ -41,12 +41,13 @@ module ADAL
     # @return TokenResponse
     def self.parse(raw_response)
       logger.verbose('Attempting to create a TokenResponse from raw response.')
-      if raw_response.nil?
+      parsed_response = raw_response && raw_response.length >= 2 ? JSON.parse(raw_response) : nil
+      if parsed_response.nil?
         ErrorResponse.new
       elsif raw_response['error']
-        ErrorResponse.new(JSON.parse(raw_response))
+        ErrorResponse.new(parsed_response)
       else
-        SuccessResponse.new(JSON.parse(raw_response))
+        SuccessResponse.new(parsed_response)
       end
     end
 


### PR DESCRIPTION
…y returning nil.

ADAL::TokenResponse.parse was receiving non-hash arguments, i.e. an empty "", which caused JSON.parse(raw_response) to give out this error: "JSON::ParserError (A JSON text must at least contain two octets!)". Added a check prior to parsing the JSON to prevent the error from being thrown.'