### PR TITLE
Unlock jwt from 1.x version dependency

### DIFF
--- a/adal.gemspec
+++ b/adal.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.1.0'
 
-  s.add_runtime_dependency 'jwt', '~> 1.5'
+  s.add_runtime_dependency 'jwt', '>= 1.5'
   s.add_runtime_dependency 'nokogiri', '~> 1.6'
   s.add_runtime_dependency 'uri_template', '~> 0.7'
 


### PR DESCRIPTION
A minor fix so we can use `jwt` version 2 and above