### PR TITLE
Fixed JSON::ParserError error

### DIFF
--- a/lib/adal/token_response.rb
+++ b/lib/adal/token_response.rb
@@ -41,7 +41,7 @@ module ADAL
     # @return TokenResponse
     def self.parse(raw_response)
       logger.verbose('Attempting to create a TokenResponse from raw response.')
-      if raw_response.nil?
+      if raw_response.nil? || raw_response.empty?
         ErrorResponse.new
       elsif raw_response['error']
         ErrorResponse.new(JSON.parse(raw_response))

--- a/samples/on_behalf_of_example/README.md
+++ b/samples/on_behalf_of_example/README.md
@@ -20,7 +20,7 @@ them to your tenant.
 2. Give this application permission to use the web application that you create
    in the next step. (You can't do this step until you've configured the Web
    Application.)
-3. In `web_app.rb`, fill in the tenant, client id and client secret fields.
+3. In `web_api.rb`, fill in the tenant, client id and client secret fields.
 
 ## Configuring the Web Application
 1. In the Azure portal, register a new Native Application. Take note of the


### PR DESCRIPTION
If 'raw_response' is an empty string, JSON::ParserError is raised. So fixed this bug.

Confirmed ruby versions:

- 2.3.3p222
- 2.3.7p456
- 2.6.1p33
- 2.6.3p62