### PR TITLE
Modified AuthenticationContext

### DIFF
--- a/lib/adal/authentication_context.rb
+++ b/lib/adal/authentication_context.rb
@@ -72,10 +72,11 @@ module ADAL
     # @param ClientCredential|ClientAssertion|ClientAssertionCertificate
     #   An object that validates the client application by adding
     #   #request_params to the OAuth request.
+    # @optional String client_secret
     # @return TokenResponse
-    def acquire_token_for_client(resource, client_cred)
+    def acquire_token_for_client(resource, client_cred, options = {})
       fail_if_arguments_nil(resource, client_cred)
-      token_request_for(client_cred).get_for_client(resource)
+      token_request_for(client_cred, options).get_for_client(resource)
     end
 
     ##
@@ -91,11 +92,12 @@ module ADAL
     #   #request_params to the OAuth request.
     # @optional String resource
     #   The resource being requested.
+    # @optional String client_secret
     # @return TokenResponse
     def acquire_token_with_authorization_code(
-      auth_code, redirect_uri, client_cred, resource = nil)
+      auth_code, redirect_uri, client_cred, resource = nil, options = {})
       fail_if_arguments_nil(auth_code, redirect_uri, client_cred)
-      token_request_for(client_cred)
+      token_request_for(client_cred, options)
         .get_with_authorization_code(auth_code, redirect_uri, resource)
     end
 
@@ -109,11 +111,12 @@ module ADAL
     #   depending on the OAuth flow. This object must support #request_params.
     # @optional String resource
     #   The resource being requested.
+    # @optional String client_secret
     # @return TokenResponse
     def acquire_token_with_refresh_token(
-      refresh_token, client_cred, resource = nil)
+      refresh_token, client_cred, resource = nil, options = {})
       fail_if_arguments_nil(refresh_token, client_cred)
-      token_request_for(client_cred)
+      token_request_for(client_cred, options)
         .get_with_refresh_token(refresh_token, resource)
     end
 
@@ -143,10 +146,11 @@ module ADAL
     # @param UserAssertion|UserCredential|UserIdentifier
     #   An object that validates the client that the requested access token is
     #   for. See the description above of the various flows.
+    # @optional String client_secret
     # @return TokenResponse
-    def acquire_token_for_user(resource, client_cred, user)
+    def acquire_token_for_user(resource, client_cred, user, options = {})
       fail_if_arguments_nil(resource, client_cred, user)
-      token_request_for(client_cred)
+      token_request_for(client_cred, options)
         .get_with_user_credential(user, resource)
     end
 
@@ -187,13 +191,13 @@ module ADAL
 
     # Helper function for creating token requests based on client credentials
     # and the current authentication context.
-    def token_request_for(client_cred)
-      TokenRequest.new(@authority, wrap_client_cred(client_cred), @token_cache)
+    def token_request_for(client_cred, options = {})
+      TokenRequest.new(@authority, wrap_client_cred(client_cred, options), @token_cache)
     end
 
-    def wrap_client_cred(client_cred)
+    def wrap_client_cred(client_cred, options = {})
       if client_cred.is_a? String
-        ClientCredential.new(client_cred)
+        ClientCredential.new(client_cred, options[:client_secret])
       else
         client_cred
       end

--- a/samples/user_credentials_example/app.rb
+++ b/samples/user_credentials_example/app.rb
@@ -28,7 +28,8 @@ ADAL::Logging.log_level = ADAL::Logger::VERBOSE
 AUTHORITY_HOST = ADAL::Authority::WORLD_WIDE_AUTHORITY
 CLIENT_ID = 'your clientid here'
 RESOURCE = 'https://graph.windows.net'
-TENANT = 'your tenant here.onmicrosoft.com'
+TENANT = 'your tenant here'
+CLIENT_SECURET = 'your clientsecret here'
 
 def prompt(*args)
   print(*args)
@@ -40,7 +41,7 @@ password = prompt 'Password: '
 
 user_cred = ADAL::UserCredential.new(username, password)
 ctx = ADAL::AuthenticationContext.new(AUTHORITY_HOST, TENANT)
-result = ctx.acquire_token_for_user(RESOURCE, CLIENT_ID, user_cred)
+result = ctx.acquire_token_for_user(RESOURCE, CLIENT_ID, user_cred, { ADAL::RequestParameters::CLIENT_SECRET => CLIENT_SECURET })
 
 case result
 when ADAL::SuccessResponse

--- a/samples/user_credentials_example/app.rb
+++ b/samples/user_credentials_example/app.rb
@@ -29,7 +29,7 @@ AUTHORITY_HOST = ADAL::Authority::WORLD_WIDE_AUTHORITY
 CLIENT_ID = 'your clientid here'
 RESOURCE = 'https://graph.windows.net'
 TENANT = 'your tenant here'
-CLIENT_SECURET = 'your clientsecret here'
+CLIENT_SECRET = 'your clientsecret here'
 
 def prompt(*args)
   print(*args)
@@ -41,7 +41,7 @@ password = prompt 'Password: '
 
 user_cred = ADAL::UserCredential.new(username, password)
 ctx = ADAL::AuthenticationContext.new(AUTHORITY_HOST, TENANT)
-result = ctx.acquire_token_for_user(RESOURCE, CLIENT_ID, user_cred, { ADAL::RequestParameters::CLIENT_SECRET => CLIENT_SECURET })
+result = ctx.acquire_token_for_user(RESOURCE, CLIENT_ID, user_cred, { ADAL::RequestParameters::CLIENT_SECRET => CLIENT_SECRET })
 
 case result
 when ADAL::SuccessResponse


### PR DESCRIPTION
It is incorrect setting TENANT configuration in `user_credentials_example`. If configured correctly, we will get the following error message:

```
ERROR -- <Correlation ID>: Parsed an ErrorResponse with error: invalid_client and error description: AADSTS7000218: The request body must contain the following parameter: 'client_assertion' or 'client_secret'.
```

So, `AuthenticationContext#acquire_token_for_use` has been modified to allow to set client_secret.